### PR TITLE
Increased gravity by 1.1x to closer match MC

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -15,7 +15,7 @@ movement_speed_walk = 4.317
 movement_speed_crouch = 1.295
 movement_speed_fast = 25.0
 
-movement_speed_jump = 6.6
+movement_speed_jump = 7.26
 movement_speed_climb = 2.35
 # TODO: Add descend speed (3.0) when available
 
@@ -23,7 +23,7 @@ movement_liquid_fluidity = 1.13
 movement_liquid_fluidity_smooth = 0.5
 movement_liquid_sink = 12
 
-movement_gravity = 10.4
+movement_gravity = 11.44
 
 # Mapgen stuff
 


### PR DESCRIPTION
Increased gravity to 110% to closer match Minecraft. Damage values are calculated on velocity, so this brings fall damage more inline with Minecraft as well. Also increased jump velocity by 10% to compensate for the higher gravity.

This resolves issue #308 until I more extensively test to see if fall damage values should then be tweaked in case gravity isn't perfectly inline with Minecraft (such as hitting your head on blocks when descending stair-like pathways or something)